### PR TITLE
Improve semantic checks for arrays

### DIFF
--- a/P5/TablaSimbolos.h
+++ b/P5/TablaSimbolos.h
@@ -15,6 +15,7 @@ struct Simbolo {
     unsigned tipo;
     unsigned dir;
     unsigned tam;
+    vector<int> dims;  // tamanos de cada dimension si es un array
 };
 
 

--- a/P5/comun.h
+++ b/P5/comun.h
@@ -3,6 +3,8 @@
 
 #include <iostream>
 #include <string>
+#include <vector>
+#include <utility>
 
 using namespace std;
 
@@ -17,6 +19,10 @@ typedef struct
     int size;
     bool isVar, isOp;
     bool arrays;
+    int nindices;                      // numero de indices en una referencia
+    vector<int> tiposIndices;          // tipos de cada indice
+    vector<pair<int,int>> comaPos;     // posiciones de las comas entre indices
+    vector<int> dims;                  // dimensiones de un array
 } MITIPO;
 
 #define YYSTYPE MITIPO


### PR DESCRIPTION
## Summary
- track array dimensions in symbols and parser attributes
- validate index counts and types in `Ref`
- suppress `ERR_NODECL` when extra indices appear
- raise `ERR_ASIG` when assigning real values to integer vars

## Testing
- `make`
- `./autocorrector-plp5.sh` *(fails: 6 tests remain)*

------
https://chatgpt.com/codex/tasks/task_e_68433417df5c83219cb1bde05d742551