### PR TITLE
Fix parser stack corruption

### DIFF
--- a/P5/plp5.y
+++ b/P5/plp5.y
@@ -27,6 +27,16 @@ extern char *yytext;
 extern FILE *yyin;
 void yyerror(char *s);
 
+/*
+ * Avoid memcpy on complex C++ semantic values.
+ */
+#undef YYCOPY
+#define YYCOPY(Dst, Src, Count)                      \
+  do {                                              \
+    for (size_t yyi = 0; yyi < (Count); ++yyi)       \
+      (Dst)[yyi] = (Src)[yyi];                       \
+  } while (0)
+
 const int MEM_TOTAL = 16384;
 const int MEM_VAR   = 16000;
 


### PR DESCRIPTION
## Summary
- prevent Bison from using `memcpy` when copying semantic values

## Testing
- `make clean && make`
- `./autocorrector-plp5.sh` *(fails: 3 tests)*

------
https://chatgpt.com/codex/tasks/task_e_684fda2667408321a80bcbf8d832d6b2